### PR TITLE
Adjust opening range bounds logic

### DIFF
--- a/Main.Cs
+++ b/Main.Cs
@@ -235,8 +235,18 @@ namespace QuantConnect.Algorithm.CSharp
             RelativeVolume = VolumeSMA.IsReady && VolumeSMA > 0 ? bar.Volume / VolumeSMA : null;
             VolumeSMA.Update(bar.EndTime, bar.Volume);
             OpeningBar = bar;
-            Upper = bar.High;
-            Lower = bar.Low;
+            if (bar.Close >= bar.Open)
+            {
+                // bullish bar: use close as upper bound and open as lower
+                Upper = bar.Close;
+                Lower = bar.Open;
+            }
+            else
+            {
+                // bearish bar: use open as upper bound and close as lower
+                Upper = bar.Open;
+                Lower = bar.Close;
+            }
         }
 
         private void EntryHandler(TradeBar bar)


### PR DESCRIPTION
## Summary
- calculate upper/lower bounds in `OpeningRangeHandler` based on bar direction

## Testing
- `mcs Main.Cs -r:System.Collections.dll -r:System.Core.dll -r:System.Runtime.dll -r:System.dll -out:test.exe` *(fails: `error CS1525: Unexpected symbol`)*


------
https://chatgpt.com/codex/tasks/task_b_688397bf2c148322baa40b40e061ec88